### PR TITLE
Update and rename zh-CN.po to zh-Hant.po

### DIFF
--- a/common/zh-Hant.po
+++ b/common/zh-Hant.po
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 msgid "Main"
-msgstr "主交易"
+msgstr "主要"
 
 msgid "Pre-market"
 msgstr "市前交易"


### PR DESCRIPTION
這是交易平臺Quantower的正體字版本的本地化文件。